### PR TITLE
HOTFIX: gtest - add googletest nuget package missing

### DIFF
--- a/gtest_sample01/packages.config
+++ b/gtest_sample01/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="gmock" version="1.10.0" targetFramework="native" />
+  <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" version="1.8.1.4" targetFramework="native" />
 </packages>


### PR DESCRIPTION
add googletest nuget package to gtest project.

It was missing in the project.

- **before patch** : cannot build test project and cannot run gtest.
- **after patch applied** : build and run gtest.

**This patch does not affect the ACS project.**
